### PR TITLE
Deleted "mem.~memify();" in exit section

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,5 +51,4 @@ int main()
 		// keep in mind it patches the value / changes it, doesn't add on to it.
 	}
 	//exit
-	mem.~memify();
 }


### PR DESCRIPTION
In C++, program automatically calls the destructor. So we don't need to call destructor.