### PR TITLE
New memmory access method, using the direct syscall, to avoid the ntdll NtReadVirtualMemory signature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,22 @@
 # Memify | Memory Manipulation
 
-Simple (Shitty) Memory Class ✔
+~~Simple (Shitty) Memory Class ✔~~
+
+Simple (Hiper Duper Kernel mode Memmory Class) Memory Class ✔
 
 Fully Pastable 🖨
 
 Comes with some utility 🛠
 
 ## Requirements
+
 C++20
 Multibyte support
 
 ## Usage
-Simply include memify/memify.h into your process.
+
+Simply include memify/memify.h into your process and add the sycall.cpp to your compile list.
+
 ```cpp
 #include "mem/memify.h"
 ```

--- a/memify/mem/syscall.cpp
+++ b/memify/mem/syscall.cpp
@@ -1,0 +1,59 @@
+#include <Windows.h>
+
+static LPVOID g_execMemory = nullptr;
+static DWORD g_currentSSN = 0xFFFFFFFF;
+
+extern "C" NTSTATUS DirectSyscall(
+    DWORD ssn,
+    HANDLE ProcessHandle,
+    PVOID BaseAddress,
+    PVOID Buffer,
+    ULONG NumberOfBytesToRead,
+    PULONG NumberOfBytesRead
+) {
+    // Shellcode base
+    unsigned char shellcode[] = {
+        0x49, 0x89, 0xCA,              // mov r10, rcx
+        0xB8, 0x00, 0x00, 0x00, 0x00,  // mov eax, SSN
+        0x0F, 0x05,                    // syscall
+        0xC3                           // ret
+    };
+
+    // Aloca memória apenas uma vez
+    if (!g_execMemory) {
+        g_execMemory = VirtualAlloc(
+            NULL,
+            sizeof(shellcode),
+            MEM_COMMIT | MEM_RESERVE,
+            PAGE_EXECUTE_READWRITE
+        );
+
+        if (!g_execMemory) {
+            return 0xC0000001L;
+        }
+    }
+
+    // Atualiza SSN se mudou
+    if (g_currentSSN != ssn) {
+        *(DWORD*)(shellcode + 4) = ssn;
+        memcpy(g_execMemory, shellcode, sizeof(shellcode));
+        FlushInstructionCache(GetCurrentProcess(), g_execMemory, sizeof(shellcode));
+        g_currentSSN = ssn;
+    }
+
+    // Tipo da função
+    typedef NTSTATUS(NTAPI* SyscallFunc)(
+        HANDLE, PVOID, PVOID, ULONG, PULONG
+        );
+
+    SyscallFunc func = (SyscallFunc)g_execMemory;
+
+    // Executa o syscall
+    return func(
+        ProcessHandle,
+        BaseAddress,
+        Buffer,
+        NumberOfBytesToRead,
+        NumberOfBytesRead
+    );
+}

--- a/memify/memify.vcxproj
+++ b/memify/memify.vcxproj
@@ -135,6 +135,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="main.cpp" />
+    <ClCompile Include="mem\syscall.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/memify/memify.vcxproj.filters
+++ b/memify/memify.vcxproj.filters
@@ -26,5 +26,8 @@
     <ClCompile Include="main.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="mem\syscall.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
I've modded your code, while mantaining the original structure to bybass ntdll hooks. It should work like this:

Original version:
App → ReadProcessMemory() → ntdll!NtReadVirtualMemory (Can be HOOKED) → Kernel

New version:
App → DirectSyscall() → Kernel (straight!)